### PR TITLE
Make sure onUnit param is required on a Transactional element.

### DIFF
--- a/src/main/java/org/apache/onami/persist/Transactional.java
+++ b/src/main/java/org/apache/onami/persist/Transactional.java
@@ -54,23 +54,24 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-public @interface Transactional {
+public @interface
+    Transactional {
 
   /**
    * A List of annotations for persistence units on which to start a transaction.
    * Default is on all persistence units.
    */
-  Class<? extends Annotation>[] onUnits() default {};
+  Class<? extends Annotation>[] onUnits();
 
   /**
-   * A list of exceptions to rollback on. Default is {@link RuntimeException}.
+   * A list of exceptions to rollback on. Default is {@link Throwable}.
    */
-  Class<? extends Exception>[] rollbackOn() default RuntimeException.class;
+  Class<? extends Throwable>[] rollbackOn() default Throwable.class;
 
   /**
    * A list of exceptions to <b>not<b> rollback on. Use this to exclude one ore more subclasses of
    * the exceptions defined in rollbackOn(). Default is none.
    */
-  Class<? extends Exception>[] ignore() default {};
+  Class<? extends Throwable>[] ignore() default {};
 
 }

--- a/src/main/java/org/apache/onami/persist/Transactional.java
+++ b/src/main/java/org/apache/onami/persist/Transactional.java
@@ -54,9 +54,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-public @interface
-    Transactional {
-
+public @interface Transactional {
   /**
    * A List of annotations for persistence units on which to start a transaction.
    * Default is on all persistence units.
@@ -73,5 +71,4 @@ public @interface
    * the exceptions defined in rollbackOn(). Default is none.
    */
   Class<? extends Throwable>[] ignore() default {};
-
 }

--- a/src/main/java/org/apache/onami/persist/Transactional.java
+++ b/src/main/java/org/apache/onami/persist/Transactional.java
@@ -57,7 +57,7 @@ import java.lang.annotation.Target;
 public @interface Transactional {
   /**
    * A List of annotations for persistence units on which to start a transaction.
-   * Default is on all persistence units.
+   * The caller can specify {} for un-annotated units.
    */
   Class<? extends Annotation>[] onUnits();
 

--- a/src/main/java/org/apache/onami/persist/TransactionalAnnotationHelper.java
+++ b/src/main/java/org/apache/onami/persist/TransactionalAnnotationHelper.java
@@ -132,8 +132,8 @@ class TransactionalAnnotationHelper {
    * @param exc     the class to search for
    * @return {@code true} when the array contains a super class of exc.
    */
-  private boolean containsSuper(Class<? extends Exception>[] classes, Throwable exc) {
-    for (Class<? extends Exception> c : classes) {
+  private boolean containsSuper(Class<? extends Throwable>[] classes, Throwable exc) {
+    for (Class<? extends Throwable> c : classes) {
       if (c.isInstance(exc)) {
         return true;
       }

--- a/src/main/java/org/apache/onami/persist/TransactionalAnnotationReader.java
+++ b/src/main/java/org/apache/onami/persist/TransactionalAnnotationReader.java
@@ -60,7 +60,7 @@ class TransactionalAnnotationReader {
   /**
    * Helper class for obtaining the default of {@link Transactional @Transactional}.
    */
-  @Transactional
+  @Transactional(onUnits = {})
   private static class DefaultTransactional {
   }
 

--- a/src/test/java/org/apache/onami/persist/TransactionalAnnotationMatcher.java
+++ b/src/test/java/org/apache/onami/persist/TransactionalAnnotationMatcher.java
@@ -53,8 +53,8 @@ public final class TransactionalAnnotationMatcher extends BaseMatcher<Transactio
     if (item instanceof Transactional) {
       Transactional transactional = (Transactional) item;
       final Set<Class<? extends Annotation>> actualUnits = asSet(transactional.onUnits());
-      final Set<Class<? extends Exception>> actualRollback = asSet(transactional.rollbackOn());
-      final Set<Class<? extends Exception>> actualIgnore = asSet(transactional.ignore());
+      final Set<Class<? extends Throwable>> actualRollback = asSet(transactional.rollbackOn());
+      final Set<Class<? extends Throwable>> actualIgnore = asSet(transactional.ignore());
 
       return actualUnits.equals(expectedUnits) && actualRollback.equals(expectedRollback) && actualIgnore.equals(
           expectedIgnore);

--- a/src/test/java/org/apache/onami/persist/TransactionalAnnotationReaderTest.java
+++ b/src/test/java/org/apache/onami/persist/TransactionalAnnotationReaderTest.java
@@ -65,7 +65,7 @@ public class TransactionalAnnotationReaderTest {
     final Transactional result = sut.readAnnotationFrom(invocation);
 
     Assert.assertThat(result,
-        TransactionalAnnotationMatcher.transactionalAnnotation(new Class[] {}, new Class[] {RuntimeException.class},
+        TransactionalAnnotationMatcher.transactionalAnnotation(new Class[] {}, new Class[] {Throwable.class},
             new Class[] {}));
   }
 

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/TransactionalWorker.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/TransactionalWorker.java
@@ -109,7 +109,7 @@ public class TransactionalWorker {
   /**
    * Check all stored entities if they actually have been persisted in the DB.
    */
-  @Transactional
+  @Transactional(onUnits = {})
   public void assertAllEntitiesHaveBeenPersisted() {
     checkState(!storedEntities.isEmpty(), "no entities to check");
     for (TestEntity storedEntity : storedEntities) {
@@ -122,7 +122,7 @@ public class TransactionalWorker {
   /**
    * Check all stored entities if they actually have NOT been persisted in the DB.
    */
-  @Transactional
+  @Transactional(onUnits = {})
   public void assertNoEntityHasBeenPersisted() {
     checkState(!storedEntities.isEmpty(), "no entities to check");
     for (TestEntity storedEntity : storedEntities) {

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnAnyThrowingNone.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnAnyThrowingNone.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnAnyThrowingNone extends TransactionalTask {
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = Exception.class)
+  @Transactional(rollbackOn = Exception.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnAnyThrowingRuntimeTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnAnyThrowingRuntimeTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnAnyThrowingRuntimeTestException extends Transactio
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = Exception.class)
+  @Transactional(rollbackOn = Exception.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnAnyThrowingTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnAnyThrowingTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnAnyThrowingTestException extends TransactionalTask
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = Exception.class)
+  @Transactional(rollbackOn = Exception.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnNoneThrowingNone.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnNoneThrowingNone.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnNoneThrowingNone extends TransactionalTask {
    * {@inheritDoc}
    */
   @Override
-  @Transactional(ignore = Exception.class)
+  @Transactional(ignore = Exception.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnNoneThrowingRuntimeTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnNoneThrowingRuntimeTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnNoneThrowingRuntimeTestException extends Transacti
    * {@inheritDoc}
    */
   @Override
-  @Transactional(ignore = Exception.class)
+  @Transactional(ignore = Exception.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnNoneThrowingTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnNoneThrowingTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnNoneThrowingTestException extends TransactionalTas
    * {@inheritDoc}
    */
   @Override
-  @Transactional(ignore = Exception.class)
+  @Transactional(ignore = Exception.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnRuntimeTestExceptionThrowingNone.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnRuntimeTestExceptionThrowingNone.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnRuntimeTestExceptionThrowingNone extends Transacti
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = RuntimeTestException.class)
+  @Transactional(rollbackOn = RuntimeTestException.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnRuntimeTestExceptionThrowingRuntimeTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnRuntimeTestExceptionThrowingRuntimeTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnRuntimeTestExceptionThrowingRuntimeTestException e
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = RuntimeTestException.class)
+  @Transactional(rollbackOn = RuntimeTestException.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnRuntimeTestExceptionThrowingTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnRuntimeTestExceptionThrowingTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnRuntimeTestExceptionThrowingTestException extends 
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = RuntimeTestException.class)
+  @Transactional(rollbackOn = RuntimeTestException.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnTestExceptionThrowingNone.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnTestExceptionThrowingNone.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnTestExceptionThrowingNone extends TransactionalTas
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = TestException.class)
+  @Transactional(rollbackOn = TestException.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnTestExceptionThrowingRuntimeTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnTestExceptionThrowingRuntimeTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnTestExceptionThrowingRuntimeTestException extends 
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = TestException.class)
+  @Transactional(rollbackOn = TestException.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();

--- a/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnTestExceptionThrowingTestException.java
+++ b/src/test/java/org/apache/onami/persist/test/transaction/testframework/tasks/TaskRollingBackOnTestExceptionThrowingTestException.java
@@ -36,7 +36,7 @@ public class TaskRollingBackOnTestExceptionThrowingTestException extends Transac
    * {@inheritDoc}
    */
   @Override
-  @Transactional(rollbackOn = TestException.class)
+  @Transactional(rollbackOn = TestException.class, onUnits = {})
   public void doTransactional() throws TestException, RuntimeTestException {
     storeEntity(new TestEntity());
     doOtherTasks();


### PR DESCRIPTION
Also ensure that default behavior is that rollback happens on all
Throwables.