### PR TITLE
Bump onami-persist version to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>org.apache.onami.persist</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Apache Onami Persistence</name>


### PR DESCRIPTION
I forgot to do this when I updated the library last week, but I spotted the need when I looked at [JJ's PR](https://github.com/tocktix/admin/pull/18108/files) that implemented the last onami-persist update.

Updating the library version number is going to be a _much_ bigger pain this time around than it was in that PR, and it makes me think we should have a brief discussion in #bazel or somewhere about how to handle libraries in the new bazel world. In gradle, there was only one place to update; now there are 258 distinct places that mention library version 1.0.6. My instinct would be to introduce a level of indirection so that anyone who wants "the latest version of the library" refers to it without naming the version specifically, but we should talk about how that gets implemented.